### PR TITLE
fix: resolve TypeScript error for Function type in test callbacks

### DIFF
--- a/src/main/__tests__/trayManager.test.ts
+++ b/src/main/__tests__/trayManager.test.ts
@@ -29,7 +29,7 @@ function createMockDeps(overrides: Record<string, unknown> = {}) {
 }
 
 describe('TrayManager', () => {
-  let callbacks: Record<string, Function>;
+  let callbacks: Record<string, () => void>;
 
   beforeEach(() => {
     callbacks = {};


### PR DESCRIPTION
## Summary
- テストの `callbacks` の型を `Record<string, Function>` → `Record<string, () => void>` に修正
- CIのビルドステップで TypeScript の strict 型チェックに失敗していた問題を修正

## Test plan
- [ ] `npx tsc --project tsconfig.main.json --noEmit` がエラーなしで通ること
- [ ] `npm test` で全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)